### PR TITLE
Wrong preferences filename issue

### DIFF
--- a/SublimeManpage.py
+++ b/SublimeManpage.py
@@ -16,7 +16,7 @@ class ManpageCommand(sublime_plugin.WindowCommand):
                                   % sublime.platform())
             return
 
-        self.window.show_input_panel("Type function name:", "",
+        self.window.show_input_panel("Type function name or command:", "",
                                      self.on_done, None, None)
 
     def on_done(self, line):

--- a/SublimeManpage.py
+++ b/SublimeManpage.py
@@ -29,7 +29,7 @@ class ManpageApiCall(threading.Thread):
         self.window = window
         self.req_function = func
         self.function_list = list()
-        self.settings = sublime.load_settings("Preferences.sublime-settings")
+        self.settings = sublime.load_settings("SublimeManpage.sublime-settings")
         self.whatis_re = re.compile(WHATIS_RE)
         threading.Thread.__init__(self)
 


### PR DESCRIPTION
Because in the plugin source code the preferences filename for getting the settings modified by the user is wrong the plugin cannot find the newly modified settings (it falls back to the default values that are included in the source code).
Due to this small bug the plugin doesn't show anything else but functions that are part of the 2 and 3 sections of the man pages.
I debugged the issue and I fixed it. Also I made a small  modification to the input panel message. Thank you!
