### PR TITLE
Repaired typo bug in commands file

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,6 +8,6 @@
 		"command": "open_file", "args":
         {
             "file": "${packages}/SublimeManpage/SublimeManpage.sublime-settings"
-        },    	
+        }
     }
 ]


### PR DESCRIPTION
Hello,

Unfortunately I didn't see the that by mistake I left an extra comma in the Default.sublime-commands file that caused an error. I repaired the typo so could you please pull it into your repository. I apologize for this and I will be more careful in the future.

P.S. Please disregard my earlier message and pull request (I cancelled it). Thank you!

Best regards,
Levi
